### PR TITLE
change: since the content_encoding field has been removed since 1.21.…

### DIFF
--- a/ngx_http_redis_module.c
+++ b/ngx_http_redis_module.c
@@ -535,7 +535,7 @@ found:
             ngx_str_set(&h->key, "Content-Encoding");
             ngx_str_set(&h->value, "gzip");
             h->lowcase_key = (u_char*) "content-encoding";
-#if (NGX_HTTP_GZIP)
+#if defined(nginx_version) && (nginx_version <= 1021006) && (NGX_HTTP_GZIP)
             u->headers_in.content_encoding = h;
 #endif
         }

--- a/ngx_http_redis_module.c
+++ b/ngx_http_redis_module.c
@@ -537,6 +537,8 @@ found:
             h->lowcase_key = (u_char*) "content-encoding";
 #if defined(nginx_version) && (nginx_version <= 1021006) && (NGX_HTTP_GZIP)
             u->headers_in.content_encoding = h;
+#elif defined(nginx_version) && (nginx_version > 1021006)
+            r->headers_out.content_encoding = h;
 #endif
         }
 


### PR DESCRIPTION
…6, this is added for compatibility.